### PR TITLE
fix: Unable to find first interface/declare

### DIFF
--- a/src/commands/keep-sorted.test.ts
+++ b/src/commands/keep-sorted.test.ts
@@ -13,6 +13,30 @@ run(
     ]
   `
   ,
+  // multi interfaces without export
+  $`
+    // @keep-sorted
+    interface A {
+      foo: number
+    }
+    // @keep-sorted
+    interface B {
+      foo: number
+    }
+  `
+  ,
+  // multi declares without export
+  $`
+    // @keep-sorted
+    const arr1 = [
+      { index: 0, name: 'foo' },
+    ]
+    // @keep-sorted
+    const arr2 = [
+      { index: 0, name: 'foo' },
+    ]
+  `
+  ,
   // Object property
   {
     code: $`

--- a/src/commands/keep-sorted.ts
+++ b/src/commands/keep-sorted.ts
@@ -31,7 +31,28 @@ export const keepSorted: Command = {
       'TSSatisfiesExpression',
     ) || ctx.findNodeBelow(
       'ExportNamedDeclaration',
+      'TSInterfaceDeclaration',
+      'VariableDeclaration',
     )
+
+    if (node?.type === 'TSInterfaceDeclaration') {
+      node = node.body
+    }
+
+    if (node?.type === 'VariableDeclaration') {
+      const dec = node.declarations[0]
+      if (!dec) {
+        node = undefined
+      }
+      else if (dec.id.type === 'ObjectPattern') {
+        node = dec.id
+      }
+      else {
+        node = Array.isArray(dec.init) ? dec.init[0] : dec.init
+        if (node && node.type !== 'ObjectExpression' && node.type !== 'ArrayExpression' && node.type !== 'TSSatisfiesExpression')
+          node = undefined
+      }
+    }
 
     // Unwrap TSSatisfiesExpression
     if (node?.type === 'TSSatisfiesExpression') {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed unexpected "Unable to find object/array/interface to sort" error for first interface/declare in two cases:

```ts
// @keep-sorted -> [keep-sorted] error: Unable to find object/array/interface to sort"
interface A {
  foo: number
}
// @keep-sorted
interface B {
  foo: number
}
```

```ts
// @keep-sorted -> [keep-sorted] error: Unable to find object/array/interface to sort"
const arr1 = [
  { index: 0, name: 'foo' },
]
// @keep-sorted
const arr2 = [
  { index: 0, name: 'foo' },
]
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
