### PR TITLE
feat: new command `keep-aligned`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,10 +18,10 @@ export default antfu(
         'command/command': 'off',
         'antfu/top-level-function': 'off',
         'style/max-statements-per-line': 'off',
-        'style/no-multi-spaces': 'off',
-        'style/comma-spacing': 'off',
-        'antfu/consistent-list-newline': 'off',
       },
+    },
+    {
+      ignores: ['src/commands/keep-aligned.md'],
     },
     {
       rules: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,9 +21,6 @@ export default antfu(
       },
     },
     {
-      ignores: ['src/commands/keep-aligned.md'],
-    },
-    {
       rules: {
         'antfu/top-level-function': 'off',
       },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,9 @@ export default antfu(
         'command/command': 'off',
         'antfu/top-level-function': 'off',
         'style/max-statements-per-line': 'off',
+        'style/no-multi-spaces': 'off',
+        'style/comma-spacing': 'off',
+        'antfu/consistent-list-newline': 'off',
       },
     },
     {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 import { hoistRegExp } from './hoist-regexp'
 import { inlineArrow } from './inline-arrow'
+import { keepAligned } from './keep-aligned'
 import { keepSorted } from './keep-sorted'
 import { keepUnique } from './keep-unique'
 import { noShorthand } from './no-shorthand'
@@ -21,6 +22,7 @@ import { toTernary } from './to-ternary'
 export {
   hoistRegExp,
   inlineArrow,
+  keepAligned,
   keepSorted,
   keepUnique,
   noShorthand,
@@ -43,6 +45,7 @@ export {
 export const builtinCommands = [
   hoistRegExp,
   inlineArrow,
+  keepAligned,
   keepSorted,
   keepUnique,
   noShorthand,

--- a/src/commands/keep-aligned.md
+++ b/src/commands/keep-aligned.md
@@ -7,7 +7,7 @@ Keep specific symbols within a block of code are aligned vertically.
 - `/// keep-aligned <symbols>`
 - `// @keep-aligned <symbols>`
 
-### Examples
+## Examples
 
 ```typescript
 // @keep-aligned , , ,
@@ -29,7 +29,7 @@ export const matrix = [
 ]
 ```
 
-#### Repeat Mode
+### Repeat Mode
 
 For the example above where `,` is the only repeating symbol for alignment, `keep-aligned*` could be used instead to indicate a repeating pattern:
 
@@ -43,3 +43,17 @@ export const matrix = [
 ```
 
 Will produce the same result.
+
+> [!TIP]
+> This rule does not work well with other spacing rules, namely `style/no-multi-spaces, style/comma-spacing, antfu/consistent-list-newline` were disabled for the example above to work. Consider adding `/* eslint-disable */` to specific ESLint rules for lines affected by this command.
+>
+> ```typescript
+> /* eslint-disable style/no-multi-spaces, style/comma-spacing, antfu/consistent-list-newline */
+> // @keep-aligned , , ,
+> export const matrix = [
+>   1    , 0    , 0 ,
+>   0.866, -0.5 , 0 ,
+>   0.5  , 0.866, 42,
+> ]
+> /* eslint-enable style/no-multi-spaces, style/comma-spacing, antfu/consistent-list-newline */
+> ```

--- a/src/commands/keep-aligned.md
+++ b/src/commands/keep-aligned.md
@@ -9,6 +9,8 @@ Keep specific symbols within a block of code are aligned vertically.
 
 ## Examples
 
+<!-- eslint-skip -->
+
 ```typescript
 // @keep-aligned , , ,
 export const matrix = [
@@ -19,6 +21,8 @@ export const matrix = [
 ```
 
 Will be converted to:
+
+<!-- eslint-skip -->
 
 ```typescript
 // @keep-aligned , , ,
@@ -32,6 +36,8 @@ export const matrix = [
 ### Repeat Mode
 
 For the example above where `,` is the only repeating symbol for alignment, `keep-aligned*` could be used instead to indicate a repeating pattern:
+
+<!-- eslint-skip -->
 
 ```typescript
 // @keep-aligned* ,

--- a/src/commands/keep-aligned.md
+++ b/src/commands/keep-aligned.md
@@ -1,0 +1,45 @@
+# `keep-aligned`
+
+Keep specific symbols within a block of code are aligned vertically.
+
+## Triggers
+
+- `/// keep-aligned <symbols>`
+- `// @keep-aligned <symbols>`
+
+### Examples
+
+```typescript
+// @keep-aligned , , ,
+export const matrix = [
+  1, 0, 0,
+  0.866, -0.5, 0,
+  0.5, 0.866, 42,
+]
+```
+
+Will be converted to:
+
+```typescript
+// @keep-aligned , , ,
+export const matrix = [
+  1    , 0    , 0 ,
+  0.866, -0.5 , 0 ,
+  0.5  , 0.866, 42,
+]
+```
+
+#### Repeat Mode
+
+For the example above where `,` is the only repeating symbol for alignment, `keep-aligned*` could be used instead to indicate a repeating pattern:
+
+```typescript
+// @keep-aligned* ,
+export const matrix = [
+  1, 0, 0,
+  0.866, -0.5, 0,
+  0.5, 0.866, 42,
+]
+```
+
+Will produce the same result.

--- a/src/commands/keep-aligned.test.ts
+++ b/src/commands/keep-aligned.test.ts
@@ -1,0 +1,86 @@
+import { $, run } from './_test-utils'
+import { keepAligned } from './keep-aligned'
+
+run(
+  keepAligned,
+  {
+    code: $`
+      // @keep-aligned , , ,
+      export const matrix = [
+        1, 0, 0,
+        0.866, -0.5, 0,
+        0.5, 0.866, 42,
+      ]
+    `,
+    output(output) {
+      expect(output).toMatchInlineSnapshot(`
+        "// @keep-aligned , , ,
+        export const matrix = [
+          1    , 0    , 0 ,
+          0.866, -0.5 , 0 ,
+          0.5  , 0.866, 42,
+        ]"
+      `)
+    },
+  },
+  {
+    code: $`
+      // @keep-aligned , , ]
+      export const matrix = [
+        [1, 0, 0],
+        [0.866, -0.5, 0],
+        [0.5, 0.866, 42],
+      ] 
+    `,
+    output(output) {
+      expect(output).toMatchInlineSnapshot(`
+        "// @keep-aligned , , ]
+        export const matrix = [
+          [1    , 0    , 0 ],
+          [0.866, -0.5 , 0 ],
+          [0.5  , 0.866, 42],
+        ] "
+      `)
+    },
+  },
+  {
+    code: $`
+      /// keep-aligned* ,
+      export const matrix = [
+        1, 0, 0, 0.866, 0.5, 0.866, 42,
+        0.866, -0.5, 0, 0.5, 0.121212,
+        0.5, 0.866, 118, 1, 0, 0, 0.866, -0.5, 12,
+      ] 
+    `,
+    output(output) {
+      expect(output).toMatchInlineSnapshot(`
+        "/// keep-aligned* ,
+        export const matrix = [
+          1    , 0    , 0  , 0.866, 0.5     , 0.866, 42   ,
+          0.866, -0.5 , 0  , 0.5  , 0.121212,
+          0.5  , 0.866, 118, 1    , 0       , 0    , 0.866, -0.5, 12,
+        ] "
+      `)
+    },
+  },
+  {
+    code: $`
+      function foo(arr: number[][], i: number, j: number) {
+        // @keep-aligned arr[ ] arr[ ] ][j
+        return arr[i - 1][j - 1] + arr[i - 1][j] + arr[i - 1][j + 1]
+          + arr[i][j - 1] + arr[i][j] + arr[i][j + 1]
+          + arr[i + 1][j - 1] + arr[i + 1][j] + arr[i][j + 1]
+      }
+    `,
+    output(output) {
+      expect(output).toMatchInlineSnapshot(`
+        "function foo(arr: number[][], i: number, j: number) {
+          // @keep-aligned arr[ ] arr[ ] ][j
+          return arr[i - 1][j - 1] + arr[i - 1][j] + arr[i - 1][j + 1]
+            +    arr[i    ][j - 1] + arr[i    ][j] + arr[i    ][j + 1]
+            +    arr[i + 1][j - 1] + arr[i + 1][j] + arr[i    ][j + 1]
+        }"
+      `)
+    },
+  },
+)

--- a/src/commands/keep-aligned.ts
+++ b/src/commands/keep-aligned.ts
@@ -1,0 +1,68 @@
+import type { Command } from '../types'
+
+const reLine = /^[/@:]\s*keep-aligned(?<repeat>\*?)(?<symbols>(\s+\S+)+)$/
+
+export const keepAligned: Command = {
+  name: 'keep-aligned',
+  commentType: 'line',
+  match: comment => comment.value.trim().match(reLine),
+  action(ctx) {
+    // this command applies to any node below
+    const node = ctx.findNodeBelow(() => true)
+    if (!node)
+      return
+
+    const alignmentSymbols = ctx.matches.groups?.symbols?.trim().split(/\s+/)
+    if (!alignmentSymbols)
+      return ctx.reportError('No alignment symbols provided')
+    const repeat = ctx.matches.groups?.repeat
+
+    const nLeadingSpaces = node.range[0] - ctx.comment.range[1] - 1
+    const text = ctx.context.sourceCode.getText(node, nLeadingSpaces)
+    const lines = text.split('\n')
+    const symbolIndices: number[] = []
+
+    const nSymbols = alignmentSymbols.length
+    if (nSymbols === 0)
+      return ctx.reportError('No alignment symbols provided')
+
+    const n = repeat ? Number.MAX_SAFE_INTEGER : nSymbols
+    let lastPos = 0
+    for (let i = 0; i < n && i < 20; i++) {
+      const symbol = alignmentSymbols[i % nSymbols]
+      const maxIndex = lines.reduce((maxIndex, line) =>
+        Math.max(line.indexOf(symbol, lastPos), maxIndex), -1)
+      symbolIndices.push(maxIndex)
+
+      if (maxIndex < 0) {
+        if (!repeat)
+          return ctx.reportError(`Alignment symbol "${symbol}" not found`)
+        else
+          break
+      }
+
+      for (let j = 0; j < lines.length; j++) {
+        const line = lines[j]
+        const index = line.indexOf(symbol, lastPos)
+        if (index < 0)
+          continue
+        if (index !== maxIndex) {
+          const padding = maxIndex - index
+          lines[j] = line.slice(0, index) + ' '.repeat(padding) + line.slice(index)
+        }
+      }
+      lastPos = maxIndex + symbol.length
+    }
+
+    const modifiedText = lines.join('\n')
+    if (text === modifiedText)
+      return
+
+    ctx.report({
+      node,
+      message: 'Keep aligned',
+      removeComment: false,
+      fix: fixer => fixer.replaceText(node, modifiedText.slice(nLeadingSpaces)),
+    })
+  },
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR implements the `keep-aligned` command, it accepts a list of symbols to align and an optional `*` at the end to indicate a repeating pattern

#### Example

```typescript
// @keep-aligned , , ,
export const matrix = [
  1    , 0    , 0 ,
  0.866, -0.5 , 0 ,
  0.5  , 0.866, 42,
]

// alternatively
// @keep-aligned* ,
export const matrix = [
  1    , 0    , 0 ,
  0.866, -0.5 , 0 ,
  0.5  , 0.866, 42,
]

```

### Linked Issues

closes #31

### Caveats and Possible Enhancements

This rule does NOT work well with other spacing rules, namely `style/no-multi-spaces, style/comma-spacing, antfu/consistent-list-newline` were disabled for the example in the markdown file to work. I don't know if it's possible for this rule to disable related spacing rules on-demand, but currently, the best solution is to disable specific eslint rules for the range/line affected by this command.

Currently which symbols to align by must be declared for this command to function. It might be possible to infer the alignment symbols based on the current alignment.