### PR TITLE
feat(reverse-if-else): new command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,7 @@ import { noShorthand } from './no-shorthand'
 import { noType } from './no-type'
 import { noXAbove } from './no-x-above'
 import { regex101 } from './regex101'
+import { reverseIfElse } from './reverse-if-else'
 import { toArrow } from './to-arrow'
 import { toDestructuring } from './to-destructuring'
 import { toDynamicImport } from './to-dynamic-import'
@@ -30,6 +31,7 @@ export {
   noType,
   noXAbove,
   regex101,
+  reverseIfElse,
   toArrow,
   toDestructuring,
   toDynamicImport,
@@ -54,6 +56,7 @@ export const builtinCommands = [
   noType,
   noXAbove,
   regex101,
+  reverseIfElse,
   toArrow,
   toDestructuring,
   toDynamicImport,

--- a/src/commands/reverse-if-else.md
+++ b/src/commands/reverse-if-else.md
@@ -1,0 +1,32 @@
+# `reverse-if-else`
+
+Reverse the order of if-else statements and negate the condition.
+
+## Triggers
+
+- `/// reverse-if-else`
+- `/// rife`
+- `/// rif`
+
+## Examples
+
+```ts
+/// reverse-if-else
+if (a === 1) {
+  a = 2
+}
+else {
+  a = 3
+}
+```
+
+Will be converted to:
+
+```ts
+if (!(a === 1)) {
+  a = 3
+}
+else {
+  a = 2
+}
+```

--- a/src/commands/reverse-if-else.test.ts
+++ b/src/commands/reverse-if-else.test.ts
@@ -1,0 +1,46 @@
+import { $, run } from './_test-utils'
+import { reverseIfElse as command } from './reverse-if-else'
+
+run(
+  command,
+  {
+    code: $`
+      /// reverse-if-else
+      const foo = 'bar'
+    `,
+    errors: ['command-error'],
+  },
+  // with else if
+  {
+    code: $`
+      /// reverse-if-else
+      if (a === 1) {
+        a = 2
+      }
+      else if (a === 2) {
+        a = 3
+      }
+    `,
+    errors: ['command-error'],
+  },
+  {
+    code: $`
+      /// reverse-if-else
+      if (a === 1) {
+        a = 2
+      }
+      else {
+        a = 3
+      }
+    `,
+    output: $`
+      if (!(a === 1)) {
+        a = 3
+      }
+      else {
+        a = 2
+      }
+    `,
+    errors: ['command-fix'],
+  },
+)

--- a/src/commands/reverse-if-else.ts
+++ b/src/commands/reverse-if-else.ts
@@ -1,0 +1,45 @@
+import type { Command } from '../types'
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+
+export const reverseIfElse: Command = {
+  name: 'reverse-if-else',
+  match: /^\s*[/:@]\s*(reverse-if-else|rife|rif)$/,
+  action(ctx) {
+    const node = ctx.findNodeBelow('IfStatement')
+
+    if (!node)
+      return ctx.reportError('Cannot find if statement')
+
+    const maybeElseNode = node?.alternate
+    if (!maybeElseNode)
+      return ctx.reportError('Cannot find else statement')
+
+    const isElseif = maybeElseNode.type === AST_NODE_TYPES.IfStatement
+    if (isElseif)
+      return ctx.reportError('Unable reverse when `else if` statement exist')
+
+    const ifNode = node.consequent
+    const elseNode = maybeElseNode
+
+    ctx.report({
+      loc: ifNode.loc,
+      message: 'Reverse if-else',
+      fix(fixer) {
+        const lineIndent = ctx.getIndentOfLine(node.loc.start.line)
+
+        const conditionText = ctx.getTextOf(node.test)
+        const ifText = ctx.getTextOf(ifNode)
+        const elseText = ctx.getTextOf(elseNode)
+
+        const str = [
+          `if (!(${conditionText})) ${elseText}`,
+          `else ${ifText}`,
+        ]
+          .map((line, idx) => idx ? lineIndent + line : line)
+          .join('\n')
+
+        return fixer.replaceText(node, str)
+      },
+    })
+  },
+}


### PR DESCRIPTION
### Description

Reverse the order of if-else statements and negate the condition.

#### Triggers

- `/// reverse-if-else`
- `/// rife`
- `/// rif`

#### Examples

```ts
/// reverse-if-else
if (a === 1) {
  a = 2
}
else {
  a = 3
}
```

Will be converted to:

```ts
if (!(a === 1)) {
  a = 3
}
else {
  a = 2
}
```

### Additional context

- Only works on standard if-else blocks (does not support [ternary expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_operator))
