### PR TITLE
feat: add `alias` property

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -12,4 +12,9 @@ export default defineBuildConfig({
   externals: [
     '@typescript-eslint/utils',
   ],
+  rollup: {
+    inlineDependencies: [
+      '@antfu/utils',
+    ],
+  },
 })

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,4 +42,11 @@ export default antfu(
         'style/type-generic-spacing': 'off',
       },
     },
+    {
+      files: ['metadata.json'],
+      rules: {
+        'jsonc/comma-dangle': 'off',
+        'style/eol-last': 'off',
+      },
+    },
   )

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
   },
   "keep-unique": {
     "alias": [
-      "Error: Have invalid value",
+      "uni",
     ],
     "commentType": "both",
   },

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,133 @@
+{
+  "hoist-regexp": {
+    "alias": [
+      "hoist-regexp",
+      "hreg",
+      "hoist-regex"
+    ],
+    "commentType": "line"
+  },
+  "inline-arrow": {
+    "alias": [
+      "ia"
+    ],
+    "commentType": "line"
+  },
+  "keep-aligned": {
+    "alias": [],
+    "commentType": "line"
+  },
+  "keep-sorted": {
+    "alias": [],
+    "commentType": "both"
+  },
+  "keep-unique": {
+    "alias": [
+      "Error: Have invalid value"
+    ],
+    "commentType": "both"
+  },
+  "no-shorthand": {
+    "alias": [
+      "nsh"
+    ],
+    "commentType": "line"
+  },
+  "no-type": {
+    "alias": [
+      "nt"
+    ],
+    "commentType": "line"
+  },
+  "no-x-above": {
+    "alias": [],
+    "commentType": "line"
+  },
+  "regex101": {
+    "alias": [],
+    "commentType": "both"
+  },
+  "reverse-if-else": {
+    "alias": [
+      "rife",
+      "rif"
+    ],
+    "commentType": "line"
+  },
+  "to-arrow": {
+    "alias": [
+      "2a"
+    ],
+    "commentType": "line"
+  },
+  "to-destructuring": {
+    "alias": [
+      "to-dest",
+      "2destructuring",
+      "2dest"
+    ],
+    "commentType": "line"
+  },
+  "to-dynamic-import": {
+    "alias": [
+      "dynamic-import"
+    ],
+    "commentType": "line"
+  },
+  "to-for-each": {
+    "alias": [
+      "foreach"
+    ],
+    "commentType": "line"
+  },
+  "to-for-of": {
+    "alias": [
+      "for-of"
+    ],
+    "commentType": "line"
+  },
+  "to-function": {
+    "alias": [
+      "to-fn",
+      "2f"
+    ],
+    "commentType": "line"
+  },
+  "to-one-line": {
+    "alias": [
+      "21l",
+      "tol"
+    ],
+    "commentType": "line"
+  },
+  "to-promise-all": {
+    "alias": [
+      "2pa"
+    ],
+    "commentType": "line"
+  },
+  "to-string-literal": {
+    "alias": [
+      "to-sl",
+      "2string-literal",
+      "2sl"
+    ],
+    "commentType": "line"
+  },
+  "to-template-literal": {
+    "alias": [
+      "to-tl",
+      "2template-literal",
+      "2tl"
+    ],
+    "commentType": "line"
+  },
+  "to-ternary": {
+    "alias": [
+      "to-3",
+      "2ternary",
+      "23"
+    ],
+    "commentType": "line"
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -3,131 +3,131 @@
     "alias": [
       "hoist-regexp",
       "hreg",
-      "hoist-regex"
+      "hoist-regex",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "inline-arrow": {
     "alias": [
-      "ia"
+      "ia",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "keep-aligned": {
     "alias": [],
-    "commentType": "line"
+    "commentType": "line",
   },
   "keep-sorted": {
     "alias": [],
-    "commentType": "both"
+    "commentType": "both",
   },
   "keep-unique": {
     "alias": [
-      "Error: Have invalid value"
+      "Error: Have invalid value",
     ],
-    "commentType": "both"
+    "commentType": "both",
   },
   "no-shorthand": {
     "alias": [
-      "nsh"
+      "nsh",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "no-type": {
     "alias": [
-      "nt"
+      "nt",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "no-x-above": {
     "alias": [],
-    "commentType": "line"
+    "commentType": "line",
   },
   "regex101": {
     "alias": [],
-    "commentType": "both"
+    "commentType": "both",
   },
   "reverse-if-else": {
     "alias": [
       "rife",
-      "rif"
+      "rif",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-arrow": {
     "alias": [
-      "2a"
+      "2a",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-destructuring": {
     "alias": [
       "to-dest",
       "2destructuring",
-      "2dest"
+      "2dest",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-dynamic-import": {
     "alias": [
-      "dynamic-import"
+      "dynamic-import",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-for-each": {
     "alias": [
-      "foreach"
+      "foreach",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-for-of": {
     "alias": [
-      "for-of"
+      "for-of",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-function": {
     "alias": [
       "to-fn",
-      "2f"
+      "2f",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-one-line": {
     "alias": [
       "21l",
-      "tol"
+      "tol",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-promise-all": {
     "alias": [
-      "2pa"
+      "2pa",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-string-literal": {
     "alias": [
       "to-sl",
       "2string-literal",
-      "2sl"
+      "2sl",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-template-literal": {
     "alias": [
       "to-tl",
       "2template-literal",
-      "2tl"
+      "2tl",
     ],
-    "commentType": "line"
+    "commentType": "line",
   },
   "to-ternary": {
     "alias": [
       "to-3",
       "2ternary",
-      "23"
+      "23",
     ],
-    "commentType": "line"
-  }
+    "commentType": "line",
+  },
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "files": [
-    "dist"
+    "dist",
+    "metadata.json"
   ],
   "scripts": {
     "build": "unbuild",

--- a/src/commands/hoist-regexp.ts
+++ b/src/commands/hoist-regexp.ts
@@ -1,8 +1,11 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 
 export const hoistRegExp: Command = {
   name: 'hoist-regexp',
-  alias: ['hoist-regexp', 'hreg', 'hoist-regex'],
+  get alias() {
+    return defineAlias(this, ['hoist-regexp', 'hreg', 'hoist-regex'])
+  },
   match: /^\s*[/:@]\s*(?:hoist-|h)reg(?:exp?)?(?:\s+(\S+)\s*)?$/,
   action(ctx) {
     const regexNode = ctx.findNodeBelow((node): node is Tree.RegExpLiteral => node.type === 'Literal' && 'regex' in node) as Tree.RegExpLiteral

--- a/src/commands/hoist-regexp.ts
+++ b/src/commands/hoist-regexp.ts
@@ -2,6 +2,7 @@ import type { Command, Tree } from '../types'
 
 export const hoistRegExp: Command = {
   name: 'hoist-regexp',
+  alias: ['hoist-regexp', 'hreg', 'hoist-regex'],
   match: /^\s*[/:@]\s*(?:hoist-|h)reg(?:exp?)?(?:\s+(\S+)\s*)?$/,
   action(ctx) {
     const regexNode = ctx.findNodeBelow((node): node is Tree.RegExpLiteral => node.type === 'Literal' && 'regex' in node) as Tree.RegExpLiteral

--- a/src/commands/hoist-regexp.ts
+++ b/src/commands/hoist-regexp.ts
@@ -1,11 +1,8 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 
 export const hoistRegExp: Command = {
   name: 'hoist-regexp',
-  get alias() {
-    return defineAlias(this, ['hoist-regexp', 'hreg', 'hoist-regex'])
-  },
+  alias: ['hoist-regexp', 'hreg', 'hoist-regex'],
   match: /^\s*[/:@]\s*(?:hoist-|h)reg(?:exp?)?(?:\s+(\S+)\s*)?$/,
   action(ctx) {
     const regexNode = ctx.findNodeBelow((node): node is Tree.RegExpLiteral => node.type === 'Literal' && 'regex' in node) as Tree.RegExpLiteral

--- a/src/commands/inline-arrow.ts
+++ b/src/commands/inline-arrow.ts
@@ -1,12 +1,9 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 import { unwrapType } from './_utils'
 
 export const inlineArrow: Command = {
   name: 'inline-arrow',
-  get alias() {
-    return defineAlias(this, ['ia'])
-  },
+  alias: ['ia'],
   match: /^\s*[/:@]\s*(inline-arrow|ia)$/,
   action(ctx) {
     const arrowFn = ctx.findNodeBelow('ArrowFunctionExpression')

--- a/src/commands/inline-arrow.ts
+++ b/src/commands/inline-arrow.ts
@@ -1,8 +1,12 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 import { unwrapType } from './_utils'
 
 export const inlineArrow: Command = {
   name: 'inline-arrow',
+  get alias() {
+    return defineAlias(this, ['ia'])
+  },
   match: /^\s*[/:@]\s*(inline-arrow|ia)$/,
   action(ctx) {
     const arrowFn = ctx.findNodeBelow('ArrowFunctionExpression')

--- a/src/commands/keep-unique.md
+++ b/src/commands/keep-unique.md
@@ -5,7 +5,7 @@ Keep array items unique, removing duplicates.
 ## Triggers
 
 - `/// keep-unique`
-- `/// uniq`
+- `/// uni`
 - `// @keep-unique`
 
 ## Examples

--- a/src/commands/keep-unique.ts
+++ b/src/commands/keep-unique.ts
@@ -12,7 +12,7 @@ const reBlock = /(?:\b|\s)@keep-uni(?:que)?(?:\b|\s|$)/
 export const keepUnique: Command = {
   name: 'keep-unique',
   get alias() {
-    return defineAlias(this, ['uniq'])
+    return defineAlias(this, ['uni'])
   },
   commentType: 'both',
   match: comment => comment.value.trim().match(comment.type === 'Line' ? reLine : reBlock),

--- a/src/commands/keep-unique.ts
+++ b/src/commands/keep-unique.ts
@@ -1,5 +1,4 @@
 import type { Command } from '../types'
-import { defineAlias } from '../utils'
 
 export interface KeepSortedInlineOptions {
   key?: string
@@ -7,13 +6,11 @@ export interface KeepSortedInlineOptions {
 }
 
 const reLine = /^[/@:]\s*(?:keep-)?uni(?:que)?$/
-const reBlock = /(?:\b|\s)@keep-uni(?:que)?(?:\b|\s|$)/
+const reBlock = /(?:\b|\s)@(?:keep-)?uni(?:que)?(?:\b|\s|$)/
 
 export const keepUnique: Command = {
   name: 'keep-unique',
-  get alias() {
-    return defineAlias(this, ['uni'])
-  },
+  alias: ['uni'],
   commentType: 'both',
   match: comment => comment.value.trim().match(comment.type === 'Line' ? reLine : reBlock),
   action(ctx) {

--- a/src/commands/keep-unique.ts
+++ b/src/commands/keep-unique.ts
@@ -1,4 +1,5 @@
 import type { Command } from '../types'
+import { defineAlias } from '../utils'
 
 export interface KeepSortedInlineOptions {
   key?: string
@@ -10,7 +11,9 @@ const reBlock = /(?:\b|\s)@keep-uni(?:que)?(?:\b|\s|$)/
 
 export const keepUnique: Command = {
   name: 'keep-unique',
-  alias: ['uniq'],
+  get alias() {
+    return defineAlias(this, ['uniq'])
+  },
   commentType: 'both',
   match: comment => comment.value.trim().match(comment.type === 'Line' ? reLine : reBlock),
   action(ctx) {

--- a/src/commands/keep-unique.ts
+++ b/src/commands/keep-unique.ts
@@ -10,6 +10,7 @@ const reBlock = /(?:\b|\s)@keep-uni(?:que)?(?:\b|\s|$)/
 
 export const keepUnique: Command = {
   name: 'keep-unique',
+  alias: ['uniq'],
   commentType: 'both',
   match: comment => comment.value.trim().match(comment.type === 'Line' ? reLine : reBlock),
   action(ctx) {

--- a/src/commands/metadata.test.ts
+++ b/src/commands/metadata.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { builtinCommands } from '.'
+
+describe('metadata', () => {
+  it('test', async () => {
+    await expect(Object.fromEntries(
+      builtinCommands.map(i => [i.name, {
+        alias: i?.alias || [],
+        commentType: i?.commentType || 'line',
+      }]),
+    )).toMatchFileSnapshot('../../metadata.json')
+  })
+})

--- a/src/commands/metadata.test.ts
+++ b/src/commands/metadata.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import { builtinCommands } from '.'
+import { defineCommand } from '../types'
 
 describe('metadata', () => {
   it('test', async () => {
     await expect(Object.fromEntries(
-      builtinCommands.map(i => [i.name, {
-        alias: i?.alias || [],
-        commentType: i?.commentType || 'line',
-      }]),
+      builtinCommands.map((i) => {
+        const { name, alias } = defineCommand(i)
+        return [name, {
+          alias,
+          commentType: i?.commentType || 'line',
+        }]
+      }),
     )).toMatchFileSnapshot('../../metadata.json')
   })
 })

--- a/src/commands/no-shorthand.ts
+++ b/src/commands/no-shorthand.ts
@@ -1,12 +1,9 @@
 import type { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import type { Command } from '../types'
-import { defineAlias } from '../utils'
 
 export const noShorthand: Command = {
   name: 'no-shorthand',
-  get alias() {
-    return defineAlias(this, ['nsh'])
-  },
+  alias: ['nsh'],
   match: /^\s*[/:@]\s*(no-shorthand|nsh)$/,
   action(ctx) {
     const nodes = ctx.findNodeBelow<AST_NODE_TYPES.Property>({

--- a/src/commands/no-shorthand.ts
+++ b/src/commands/no-shorthand.ts
@@ -3,6 +3,7 @@ import type { Command } from '../types'
 
 export const noShorthand: Command = {
   name: 'no-shorthand',
+  alias: ['nsh'],
   match: /^\s*[/:@]\s*(no-shorthand|nsh)$/,
   action(ctx) {
     const nodes = ctx.findNodeBelow<AST_NODE_TYPES.Property>({

--- a/src/commands/no-shorthand.ts
+++ b/src/commands/no-shorthand.ts
@@ -1,9 +1,12 @@
 import type { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import type { Command } from '../types'
+import { defineAlias } from '../utils'
 
 export const noShorthand: Command = {
   name: 'no-shorthand',
-  alias: ['nsh'],
+  get alias() {
+    return defineAlias(this, ['nsh'])
+  },
   match: /^\s*[/:@]\s*(no-shorthand|nsh)$/,
   action(ctx) {
     const nodes = ctx.findNodeBelow<AST_NODE_TYPES.Property>({

--- a/src/commands/no-type.ts
+++ b/src/commands/no-type.ts
@@ -2,6 +2,7 @@ import type { Command } from '../types'
 
 export const noType: Command = {
   name: 'no-type',
+  alias: ['nt'],
   match: /^\s*[/:@]\s*(no-type|nt)$/,
   action(ctx) {
     const nodes = ctx.findNodeBelow({

--- a/src/commands/no-type.ts
+++ b/src/commands/no-type.ts
@@ -1,8 +1,11 @@
 import type { Command } from '../types'
+import { defineAlias } from '../utils'
 
 export const noType: Command = {
   name: 'no-type',
-  alias: ['nt'],
+  get alias() {
+    return defineAlias(this, ['nt'])
+  },
   match: /^\s*[/:@]\s*(no-type|nt)$/,
   action(ctx) {
     const nodes = ctx.findNodeBelow({

--- a/src/commands/no-type.ts
+++ b/src/commands/no-type.ts
@@ -1,11 +1,8 @@
 import type { Command } from '../types'
-import { defineAlias } from '../utils'
 
 export const noType: Command = {
   name: 'no-type',
-  get alias() {
-    return defineAlias(this, ['nt'])
-  },
+  alias: ['nt'],
   match: /^\s*[/:@]\s*(no-type|nt)$/,
   action(ctx) {
     const nodes = ctx.findNodeBelow({

--- a/src/commands/reverse-if-else.ts
+++ b/src/commands/reverse-if-else.ts
@@ -3,6 +3,7 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
 export const reverseIfElse: Command = {
   name: 'reverse-if-else',
+  alias: ['rife', 'rif'],
   match: /^\s*[/:@]\s*(reverse-if-else|rife|rif)$/,
   action(ctx) {
     const node = ctx.findNodeBelow('IfStatement')

--- a/src/commands/reverse-if-else.ts
+++ b/src/commands/reverse-if-else.ts
@@ -1,9 +1,12 @@
 import type { Command } from '../types'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+import { defineAlias } from '../utils'
 
 export const reverseIfElse: Command = {
   name: 'reverse-if-else',
-  alias: ['rife', 'rif'],
+  get alias() {
+    return defineAlias(this, ['rife', 'rif'])
+  },
   match: /^\s*[/:@]\s*(reverse-if-else|rife|rif)$/,
   action(ctx) {
     const node = ctx.findNodeBelow('IfStatement')

--- a/src/commands/reverse-if-else.ts
+++ b/src/commands/reverse-if-else.ts
@@ -1,12 +1,9 @@
 import type { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import type { Command } from '../types'
-import { defineAlias } from '../utils'
 
 export const reverseIfElse: Command = {
   name: 'reverse-if-else',
-  get alias() {
-    return defineAlias(this, ['rife', 'rif'])
-  },
+  alias: ['rife', 'rif'],
   match: /^\s*[/:@]\s*(reverse-if-else|rife|rif)$/,
   action(ctx) {
     const node = ctx.findNodeBelow('IfStatement')

--- a/src/commands/to-arrow.ts
+++ b/src/commands/to-arrow.ts
@@ -1,8 +1,11 @@
 import type { Command } from '../types'
+import { defineAlias } from '../utils'
 
 export const toArrow: Command = {
   name: 'to-arrow',
-  alias: ['2a'],
+  get alias() {
+    return defineAlias(this, ['2a'])
+  },
   match: /^\s*[/:@]\s*(to-arrow|2a|ta)$/,
   action(ctx) {
     const fn = ctx.findNodeBelow('FunctionDeclaration', 'FunctionExpression')

--- a/src/commands/to-arrow.ts
+++ b/src/commands/to-arrow.ts
@@ -1,11 +1,8 @@
 import type { Command } from '../types'
-import { defineAlias } from '../utils'
 
 export const toArrow: Command = {
   name: 'to-arrow',
-  get alias() {
-    return defineAlias(this, ['2a'])
-  },
+  alias: ['2a'],
   match: /^\s*[/:@]\s*(to-arrow|2a|ta)$/,
   action(ctx) {
     const fn = ctx.findNodeBelow('FunctionDeclaration', 'FunctionExpression')

--- a/src/commands/to-arrow.ts
+++ b/src/commands/to-arrow.ts
@@ -2,6 +2,7 @@ import type { Command } from '../types'
 
 export const toArrow: Command = {
   name: 'to-arrow',
+  alias: ['2a'],
   match: /^\s*[/:@]\s*(to-arrow|2a|ta)$/,
   action(ctx) {
     const fn = ctx.findNodeBelow('FunctionDeclaration', 'FunctionExpression')

--- a/src/commands/to-destructuring.ts
+++ b/src/commands/to-destructuring.ts
@@ -1,8 +1,11 @@
 import type { Command } from '../types'
+import { defineAlias } from '../utils'
 
 export const toDestructuring: Command = {
   name: 'to-destructuring',
-  alias: ['to-dest', '2destructuring', '2dest'],
+  get alias() {
+    return defineAlias(this, ['to-dest', '2destructuring', '2dest'])
+  },
   match: /^\s*[/:@]\s*(?:to-|2)(?:destructuring|dest)$/i,
   action(ctx) {
     const node = ctx.findNodeBelow(

--- a/src/commands/to-destructuring.ts
+++ b/src/commands/to-destructuring.ts
@@ -2,6 +2,7 @@ import type { Command } from '../types'
 
 export const toDestructuring: Command = {
   name: 'to-destructuring',
+  alias: ['to-dest', '2destructuring', '2dest'],
   match: /^\s*[/:@]\s*(?:to-|2)(?:destructuring|dest)$/i,
   action(ctx) {
     const node = ctx.findNodeBelow(

--- a/src/commands/to-destructuring.ts
+++ b/src/commands/to-destructuring.ts
@@ -1,11 +1,8 @@
 import type { Command } from '../types'
-import { defineAlias } from '../utils'
 
 export const toDestructuring: Command = {
   name: 'to-destructuring',
-  get alias() {
-    return defineAlias(this, ['to-dest', '2destructuring', '2dest'])
-  },
+  alias: ['to-dest', '2destructuring', '2dest'],
   match: /^\s*[/:@]\s*(?:to-|2)(?:destructuring|dest)$/i,
   action(ctx) {
     const node = ctx.findNodeBelow(

--- a/src/commands/to-dynamic-import.ts
+++ b/src/commands/to-dynamic-import.ts
@@ -2,6 +2,7 @@ import type { Command, Tree } from '../types'
 
 export const toDynamicImport: Command = {
   name: 'to-dynamic-import',
+  alias: ['dynamic-import'],
   match: /^\s*[/:@]\s*(?:to-|2)?(?:dynamic|d)(?:-?import)?$/i,
   action(ctx) {
     const node = ctx.findNodeBelow('ImportDeclaration')

--- a/src/commands/to-dynamic-import.ts
+++ b/src/commands/to-dynamic-import.ts
@@ -1,11 +1,8 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 
 export const toDynamicImport: Command = {
   name: 'to-dynamic-import',
-  get alias() {
-    return defineAlias(this, ['dynamic-import'])
-  },
+  alias: ['dynamic-import'],
   match: /^\s*[/:@]\s*(?:to-|2)?(?:dynamic|d)(?:-?import)?$/i,
   action(ctx) {
     const node = ctx.findNodeBelow('ImportDeclaration')

--- a/src/commands/to-dynamic-import.ts
+++ b/src/commands/to-dynamic-import.ts
@@ -1,8 +1,11 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 
 export const toDynamicImport: Command = {
   name: 'to-dynamic-import',
-  alias: ['dynamic-import'],
+  get alias() {
+    return defineAlias(this, ['dynamic-import'])
+  },
   match: /^\s*[/:@]\s*(?:to-|2)?(?:dynamic|d)(?:-?import)?$/i,
   action(ctx) {
     const node = ctx.findNodeBelow('ImportDeclaration')

--- a/src/commands/to-for-each.ts
+++ b/src/commands/to-for-each.ts
@@ -1,5 +1,4 @@
 import type { Command, NodeType, Tree } from '../types'
-import { defineAlias } from '../utils'
 
 export const FOR_TRAVERSE_IGNORE: NodeType[] = [
   'FunctionDeclaration',
@@ -15,9 +14,7 @@ export const FOR_TRAVERSE_IGNORE: NodeType[] = [
 
 export const toForEach: Command = {
   name: 'to-for-each',
-  get alias() {
-    return defineAlias(this, ['foreach'])
-  },
+  alias: ['foreach'],
   match: /^\s*[/:@]\s*(?:to-|2)?for-?each$/i,
   action(ctx) {
     const node = ctx.findNodeBelow('ForInStatement', 'ForOfStatement')

--- a/src/commands/to-for-each.ts
+++ b/src/commands/to-for-each.ts
@@ -14,6 +14,7 @@ export const FOR_TRAVERSE_IGNORE: NodeType[] = [
 
 export const toForEach: Command = {
   name: 'to-for-each',
+  alias: ['foreach'],
   match: /^\s*[/:@]\s*(?:to-|2)?for-?each$/i,
   action(ctx) {
     const node = ctx.findNodeBelow('ForInStatement', 'ForOfStatement')

--- a/src/commands/to-for-each.ts
+++ b/src/commands/to-for-each.ts
@@ -1,4 +1,5 @@
 import type { Command, NodeType, Tree } from '../types'
+import { defineAlias } from '../utils'
 
 export const FOR_TRAVERSE_IGNORE: NodeType[] = [
   'FunctionDeclaration',
@@ -14,7 +15,9 @@ export const FOR_TRAVERSE_IGNORE: NodeType[] = [
 
 export const toForEach: Command = {
   name: 'to-for-each',
-  alias: ['foreach'],
+  get alias() {
+    return defineAlias(this, ['foreach'])
+  },
   match: /^\s*[/:@]\s*(?:to-|2)?for-?each$/i,
   action(ctx) {
     const node = ctx.findNodeBelow('ForInStatement', 'ForOfStatement')

--- a/src/commands/to-for-of.ts
+++ b/src/commands/to-for-of.ts
@@ -1,12 +1,9 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 import { FOR_TRAVERSE_IGNORE } from './to-for-each'
 
 export const toForOf: Command = {
   name: 'to-for-of',
-  get alias() {
-    return defineAlias(this, ['for-of'])
-  },
+  alias: ['for-of'],
   match: /^\s*[/:@]\s*(?:to-|2)?for-?of$/i,
   action(ctx) {
     const target = ctx.findNodeBelow((node) => {

--- a/src/commands/to-for-of.ts
+++ b/src/commands/to-for-of.ts
@@ -3,6 +3,7 @@ import { FOR_TRAVERSE_IGNORE } from './to-for-each'
 
 export const toForOf: Command = {
   name: 'to-for-of',
+  alias: ['for-of'],
   match: /^\s*[/:@]\s*(?:to-|2)?for-?of$/i,
   action(ctx) {
     const target = ctx.findNodeBelow((node) => {

--- a/src/commands/to-for-of.ts
+++ b/src/commands/to-for-of.ts
@@ -1,9 +1,12 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 import { FOR_TRAVERSE_IGNORE } from './to-for-each'
 
 export const toForOf: Command = {
   name: 'to-for-of',
-  alias: ['for-of'],
+  get alias() {
+    return defineAlias(this, ['for-of'])
+  },
   match: /^\s*[/:@]\s*(?:to-|2)?for-?of$/i,
   action(ctx) {
     const target = ctx.findNodeBelow((node) => {

--- a/src/commands/to-function.ts
+++ b/src/commands/to-function.ts
@@ -1,11 +1,8 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 
 export const toFunction: Command = {
   name: 'to-function',
-  get alias() {
-    return defineAlias(this, ['to-fn', '2f'])
-  },
+  alias: ['to-fn', '2f'],
   match: /^\s*[/:@]\s*(to-(?:fn|function)|2f|tf)$/,
   action(ctx) {
     const arrowFn = ctx.findNodeBelow('ArrowFunctionExpression')

--- a/src/commands/to-function.ts
+++ b/src/commands/to-function.ts
@@ -1,8 +1,11 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 
 export const toFunction: Command = {
   name: 'to-function',
-  alias: ['to-fn', '2f'],
+  get alias() {
+    return defineAlias(this, ['to-fn', '2f'])
+  },
   match: /^\s*[/:@]\s*(to-(?:fn|function)|2f|tf)$/,
   action(ctx) {
     const arrowFn = ctx.findNodeBelow('ArrowFunctionExpression')

--- a/src/commands/to-function.ts
+++ b/src/commands/to-function.ts
@@ -2,6 +2,7 @@ import type { Command, Tree } from '../types'
 
 export const toFunction: Command = {
   name: 'to-function',
+  alias: ['to-fn', '2f'],
   match: /^\s*[/:@]\s*(to-(?:fn|function)|2f|tf)$/,
   action(ctx) {
     const arrowFn = ctx.findNodeBelow('ArrowFunctionExpression')

--- a/src/commands/to-one-line.ts
+++ b/src/commands/to-one-line.ts
@@ -1,11 +1,8 @@
 import type { Command, NodeType, Tree } from '../types'
-import { defineAlias } from '../utils'
 
 export const toOneLine: Command = {
   name: 'to-one-line',
-  get alias() {
-    return defineAlias(this, ['21l', 'tol'])
-  },
+  alias: ['21l', 'tol'],
   match: /^[/@:]\s*(?:to-one-line|21l|tol)$/,
   action(ctx) {
     const node = ctx.findNodeBelow(

--- a/src/commands/to-one-line.ts
+++ b/src/commands/to-one-line.ts
@@ -2,6 +2,7 @@ import type { Command, NodeType, Tree } from '../types'
 
 export const toOneLine: Command = {
   name: 'to-one-line',
+  alias: ['21l', 'tol'],
   match: /^[/@:]\s*(?:to-one-line|21l|tol)$/,
   action(ctx) {
     const node = ctx.findNodeBelow(

--- a/src/commands/to-one-line.ts
+++ b/src/commands/to-one-line.ts
@@ -1,8 +1,11 @@
 import type { Command, NodeType, Tree } from '../types'
+import { defineAlias } from '../utils'
 
 export const toOneLine: Command = {
   name: 'to-one-line',
-  alias: ['21l', 'tol'],
+  get alias() {
+    return defineAlias(this, ['21l', 'tol'])
+  },
   match: /^[/@:]\s*(?:to-one-line|21l|tol)$/,
   action(ctx) {
     const node = ctx.findNodeBelow(

--- a/src/commands/to-promise-all.ts
+++ b/src/commands/to-promise-all.ts
@@ -1,14 +1,11 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 
 type TargetNode = Tree.VariableDeclaration | Tree.ExpressionStatement
 type TargetDeclarator = Tree.VariableDeclarator | Tree.AwaitExpression
 
 export const toPromiseAll: Command = {
   name: 'to-promise-all',
-  get alias() {
-    return defineAlias(this, ['2pa'])
-  },
+  alias: ['2pa'],
   match: /^[/@:]\s*(?:to-|2)(?:promise-all|pa)$/,
   action(ctx) {
     const parent = ctx.getParentBlock()

--- a/src/commands/to-promise-all.ts
+++ b/src/commands/to-promise-all.ts
@@ -5,6 +5,7 @@ type TargetDeclarator = Tree.VariableDeclarator | Tree.AwaitExpression
 
 export const toPromiseAll: Command = {
   name: 'to-promise-all',
+  alias: ['2pa'],
   match: /^[/@:]\s*(?:to-|2)(?:promise-all|pa)$/,
   action(ctx) {
     const parent = ctx.getParentBlock()

--- a/src/commands/to-promise-all.ts
+++ b/src/commands/to-promise-all.ts
@@ -1,11 +1,14 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 
 type TargetNode = Tree.VariableDeclaration | Tree.ExpressionStatement
 type TargetDeclarator = Tree.VariableDeclarator | Tree.AwaitExpression
 
 export const toPromiseAll: Command = {
   name: 'to-promise-all',
-  alias: ['2pa'],
+  get alias() {
+    return defineAlias(this, ['2pa'])
+  },
   match: /^[/@:]\s*(?:to-|2)(?:promise-all|pa)$/,
   action(ctx) {
     const parent = ctx.getParentBlock()

--- a/src/commands/to-string-literal.ts
+++ b/src/commands/to-string-literal.ts
@@ -1,9 +1,12 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 import { getNodesByIndexes, parseToNumberArray } from './_utils'
 
 export const toStringLiteral: Command = {
   name: 'to-string-literal',
-  alias: ['to-sl', '2string-literal', '2sl'],
+  get alias() {
+    return defineAlias(this, ['to-sl', '2string-literal', '2sl'])
+  },
   match: /^\s*[/:@]\s*(?:to-|2)?(?:string-literal|sl)\s*(\S.*)?$/,
   action(ctx) {
     const numbers = ctx.matches[1]

--- a/src/commands/to-string-literal.ts
+++ b/src/commands/to-string-literal.ts
@@ -1,12 +1,9 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 import { getNodesByIndexes, parseToNumberArray } from './_utils'
 
 export const toStringLiteral: Command = {
   name: 'to-string-literal',
-  get alias() {
-    return defineAlias(this, ['to-sl', '2string-literal', '2sl'])
-  },
+  alias: ['to-sl', '2string-literal', '2sl'],
   match: /^\s*[/:@]\s*(?:to-|2)?(?:string-literal|sl)\s*(\S.*)?$/,
   action(ctx) {
     const numbers = ctx.matches[1]

--- a/src/commands/to-string-literal.ts
+++ b/src/commands/to-string-literal.ts
@@ -3,6 +3,7 @@ import { getNodesByIndexes, parseToNumberArray } from './_utils'
 
 export const toStringLiteral: Command = {
   name: 'to-string-literal',
+  alias: ['to-sl', '2string-literal', '2sl'],
   match: /^\s*[/:@]\s*(?:to-|2)?(?:string-literal|sl)\s*(\S.*)?$/,
   action(ctx) {
     const numbers = ctx.matches[1]

--- a/src/commands/to-template-literal.ts
+++ b/src/commands/to-template-literal.ts
@@ -1,11 +1,14 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 import { getNodesByIndexes, parseToNumberArray } from './_utils'
 
 type NodeTypes = Tree.StringLiteral | Tree.BinaryExpression
 
 export const toTemplateLiteral: Command = {
   name: 'to-template-literal',
-  alias: ['to-tl', '2template-literal', '2tl'],
+  get alias() {
+    return defineAlias(this, ['to-tl', '2template-literal', '2tl'])
+  },
   match: /^\s*[/:@]\s*(?:to-|2)?(?:template-literal|tl)\s*(\S.*)?$/,
   action(ctx) {
     const numbers = ctx.matches[1]

--- a/src/commands/to-template-literal.ts
+++ b/src/commands/to-template-literal.ts
@@ -1,14 +1,11 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 import { getNodesByIndexes, parseToNumberArray } from './_utils'
 
 type NodeTypes = Tree.StringLiteral | Tree.BinaryExpression
 
 export const toTemplateLiteral: Command = {
   name: 'to-template-literal',
-  get alias() {
-    return defineAlias(this, ['to-tl', '2template-literal', '2tl'])
-  },
+  alias: ['to-tl', '2template-literal', '2tl'],
   match: /^\s*[/:@]\s*(?:to-|2)?(?:template-literal|tl)\s*(\S.*)?$/,
   action(ctx) {
     const numbers = ctx.matches[1]

--- a/src/commands/to-template-literal.ts
+++ b/src/commands/to-template-literal.ts
@@ -5,6 +5,7 @@ type NodeTypes = Tree.StringLiteral | Tree.BinaryExpression
 
 export const toTemplateLiteral: Command = {
   name: 'to-template-literal',
+  alias: ['to-tl', '2template-literal', '2tl'],
   match: /^\s*[/:@]\s*(?:to-|2)?(?:template-literal|tl)\s*(\S.*)?$/,
   action(ctx) {
     const numbers = ctx.matches[1]

--- a/src/commands/to-ternary.ts
+++ b/src/commands/to-ternary.ts
@@ -2,6 +2,7 @@ import type { Command, Tree } from '../types'
 
 export const toTernary: Command = {
   name: 'to-ternary',
+  alias: ['to-3', '2ternary', '23'],
   match: /^\s*[/:@]\s*(?:to-|2)(?:ternary|3)$/,
   action(ctx) {
     const node = ctx.findNodeBelow('IfStatement')

--- a/src/commands/to-ternary.ts
+++ b/src/commands/to-ternary.ts
@@ -1,8 +1,11 @@
 import type { Command, Tree } from '../types'
+import { defineAlias } from '../utils'
 
 export const toTernary: Command = {
   name: 'to-ternary',
-  alias: ['to-3', '2ternary', '23'],
+  get alias() {
+    return defineAlias(this, ['to-3', '2ternary', '23'])
+  },
   match: /^\s*[/:@]\s*(?:to-|2)(?:ternary|3)$/,
   action(ctx) {
     const node = ctx.findNodeBelow('IfStatement')

--- a/src/commands/to-ternary.ts
+++ b/src/commands/to-ternary.ts
@@ -1,11 +1,8 @@
 import type { Command, Tree } from '../types'
-import { defineAlias } from '../utils'
 
 export const toTernary: Command = {
   name: 'to-ternary',
-  get alias() {
-    return defineAlias(this, ['to-3', '2ternary', '23'])
-  },
+  alias: ['to-3', '2ternary', '23'],
   match: /^\s*[/:@]\s*(?:to-|2)(?:ternary|3)$/,
   action(ctx) {
     const node = ctx.findNodeBelow('IfStatement')

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,10 @@ export interface Command {
    */
   name: string
   /**
+   * The alias of the command name
+   */
+  alias?: string[]
+  /**
    * RegExp to match the comment, without the leading `//` or `/*`
    */
   match: RegExp | ((comment: Tree.Comment) => RegExpMatchArray | boolean | undefined | null)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { TSESLint as Linter, TSESTree as Tree } from '@typescript-eslint/utils'
 import type { CommandContext } from './context'
+import { defineAlias } from './utils'
 
 export type { CommandContext, Linter, Tree }
 
@@ -93,7 +94,12 @@ export type CommandReportErrorCauseDescriptor = {
 }
 
 export function defineCommand(command: Command) {
-  return command
+  const alias = defineAlias(command, command.alias ?? [])
+
+  return {
+    ...command,
+    alias,
+  }
 }
 
 export interface FindNodeOptions<Keys extends Tree.Node['type'], All extends boolean | undefined = false> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,14 +93,10 @@ export function defineAlias(command: Command, names: string[]): string[] {
       const tokens = [`/ ${name}`, `@${name}`, `:${name}`]
 
       return tokens.every((token) => {
-        if (isFunction(match)) {
-          const res = !!match(toLineComment(token))
-
-          return res
-        }
-        else {
+        if (isFunction(match))
+          return !!match(toLineComment(token))
+        else
           return token.match(match) !== null
-        }
       })
     }
     const checkBlock = () => {
@@ -111,15 +107,12 @@ export function defineAlias(command: Command, names: string[]): string[] {
         return token.match(match) !== null
     }
 
-    if (commentType === 'line') {
+    if (commentType === 'line')
       return checkLine()
-    }
-    else if (commentType === 'block') {
+    else if (commentType === 'block')
       return checkBlock()
-    }
-    else {
+    else
       return checkLine() && checkBlock()
-    }
   },
   )
     ? names

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,7 +116,7 @@ export function defineAlias(command: Command, names: string[]): string[] {
   },
   )
     ? names
-    : ['Error: Have invalid value']
+    : []
 }
 
 export function toLineComment(token: string): Tree.LineComment {


### PR DESCRIPTION
### Description

Add `alias` for flexible command pattern matching

Could be useful in [vscode-eslint-codemod](https://github.com/kvoon3/vscode-eslint-codemod)
